### PR TITLE
Update casing in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# remote-collab
+# Remote Collaboration with Github
 
 This repository contains tutorials and projects for remote collaboration using Github.
 


### PR DESCRIPTION
This PR updates the casing in the README header from `remote-collab` to `Remote Collaboration with Github`.